### PR TITLE
# Issue #17: 減損損失の集計ロジックとダッシュボード表示、減損処理機能の実装

### DIFF
--- a/app/controllers/impairments_controller.rb
+++ b/app/controllers/impairments_controller.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class ImpairmentsController < ApplicationController
+  before_action :require_login
+
+  def index
+    # ステータスが「完了」以外の在庫を表示対象とする
+    @stocks = current_user.stocks.includes(:category).not_completed.order(
+      Arel.sql('purchase_date DESC NULLS LAST, created_at DESC')
+    )
+  end
+
+  def create
+    stock_ids = params[:stock_ids] || []
+
+    if stock_ids.empty?
+      redirect_to impairments_path, danger: I18n.t("controllers.impairments.no_selection")
+      return
+    end
+
+    # 選択された在庫を取得（自分の在庫のみ）
+    stocks = current_user.stocks.not_completed.where(id: stock_ids)
+
+    if stocks.empty?
+      redirect_to impairments_path, danger: I18n.t("controllers.impairments.invalid_selection")
+      return
+    end
+
+    # 減損処理を実行
+    processed_count = 0
+    ActiveRecord::Base.transaction do
+      stocks.each do |stock|
+        # ステータスを「減損損失(impaired: 40)」に変更
+        stock.status = :impaired
+
+        # book_valueを1円に設定
+        stock.book_value = 1
+
+        # impairment_lossを再計算（purchase_price - book_value）
+        stock.impairment_loss = (stock.purchase_price || 0) - stock.book_value
+        # 0円以上に制限
+        stock.impairment_loss = [stock.impairment_loss, 0].max
+
+        stock.save!
+        processed_count += 1
+      end
+    end
+
+    redirect_to root_path, success: I18n.t("controllers.impairments.processed", count: processed_count)
+  rescue StandardError
+    redirect_to impairments_path, danger: I18n.t("controllers.impairments.process_failed")
+  end
+end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
 class StaticPagesController < ApplicationController
-  def top; end
+  before_action :require_login
+
+  def top
+    @total_inventory_value = current_user.stocks.total_inventory_value
+    @total_knowledge_asset_value = current_user.stocks.total_knowledge_asset_value
+    @total_impairment_loss = current_user.stocks.total_impairment_loss
+  end
 end

--- a/app/models/stock.rb
+++ b/app/models/stock.rb
@@ -51,23 +51,26 @@ class Stock < ApplicationRecord
 
   def set_book_value_and_impairment_loss
     return unless purchase_price
+    return unless attributes_exist?
 
-    # カラムが存在することを確認
-    return unless has_attribute?(:book_value) && has_attribute?(:impairment_loss)
+    update_book_value
+    calculate_impairment_loss
+  end
 
-    # book_valueにpurchase_priceをコピー
-    # 新規作成時または購入金額が変更された場合は、常に更新
+  def attributes_exist?
+    has_attribute?(:book_value) && has_attribute?(:impairment_loss)
+  end
+
+  def update_book_value
     if new_record?
       self.book_value = purchase_price if book_value.nil? || book_value.zero?
     elsif purchase_price_changed?
-      # 編集時に購入金額が変更された場合、帳簿価額も更新
       self.book_value = purchase_price
     end
+  end
 
-    # impairment_lossを計算（purchase_price - book_value）
+  def calculate_impairment_loss
     self.impairment_loss = purchase_price - book_value
-    # 0円以上に制限
     self.impairment_loss = [impairment_loss, 0].max
   end
 end
-

--- a/app/views/impairments/index.html.erb
+++ b/app/views/impairments/index.html.erb
@@ -18,8 +18,8 @@
               <div class="form-control">
                 <label class="label cursor-pointer justify-start gap-3">
                   <%= check_box_tag "stock_ids[]", stock.id, false, class: "checkbox checkbox-primary", id: "stock_#{stock.id}" %>
-                  <div class="flex-1">
-                    <h2 class="card-title"><%= stock.title %></h2>
+                  <div class="flex-1 min-w-0 overflow-hidden">
+                    <h2 class="card-title break-words"><%= stock.title %></h2>
                     <div class="space-y-2 mt-2">
                       <p>
                         <span class="font-semibold">カテゴリ:</span>

--- a/app/views/impairments/index.html.erb
+++ b/app/views/impairments/index.html.erb
@@ -1,0 +1,112 @@
+<div class="mb-6">
+  <div class="mb-4">
+    <h1 class="text-3xl font-bold">減損処理</h1>
+    <p class="text-gray-600 mt-2">減損処理を実行する在庫を選択してください。ステータスが「完了」以外の在庫が表示されています。</p>
+  </div>
+
+  <%= form_with url: impairments_path, method: :post, local: true, id: "impairment-form", class: "space-y-4" do |f| %>
+    <% if @stocks.any? %>
+      <div class="mb-4">
+        <button type="button" id="select-all" class="btn btn-sm btn-outline mb-4">全て選択</button>
+        <button type="button" id="deselect-all" class="btn btn-sm btn-outline mb-4">全て解除</button>
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        <% @stocks.each do |stock| %>
+          <div class="card bg-base-100 shadow-xl">
+            <div class="card-body">
+              <div class="form-control">
+                <label class="label cursor-pointer justify-start gap-3">
+                  <%= check_box_tag "stock_ids[]", stock.id, false, class: "checkbox checkbox-primary", id: "stock_#{stock.id}" %>
+                  <div class="flex-1">
+                    <h2 class="card-title"><%= stock.title %></h2>
+                    <div class="space-y-2 mt-2">
+                      <p>
+                        <span class="font-semibold">カテゴリ:</span>
+                        <span class="badge badge-outline"><%= stock.category.name %></span>
+                      </p>
+                      <p>
+                        <span class="font-semibold">購入金額:</span>
+                        <span><%= number_to_currency(stock.purchase_price, unit: "¥", format: "%u %n", precision: 0) %></span>
+                      </p>
+                      <p>
+                        <span class="font-semibold">帳簿価額:</span>
+                        <span><%= number_to_currency(stock.book_value || 0, unit: "¥", format: "%u %n", precision: 0) %></span>
+                      </p>
+                      <p>
+                        <span class="font-semibold">減損損失:</span>
+                        <span class="text-error"><%= number_to_currency(stock.impairment_loss || 0, unit: "¥", format: "%u %n", precision: 0) %></span>
+                      </p>
+                      <% if stock.purchase_date %>
+                        <p>
+                          <span class="font-semibold">購入日:</span>
+                          <span><%= stock.purchase_date.strftime("%Y年%m月%d日") %></span>
+                        </p>
+                      <% end %>
+                      <p>
+                        <span class="font-semibold">ステータス:</span>
+                        <span class="badge <%= status_badge_class(stock.status) %>"><%= I18n.t("activerecord.enums.stock.status.#{stock.status}") %></span>
+                      </p>
+                    </div>
+                  </div>
+                </label>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      </div>
+
+      <div class="mt-6">
+        <%= f.submit "減損処理実行", class: "btn btn-error btn-lg w-full md:w-auto", id: "impairment-submit", data: { turbo_confirm: "減損処理を実行しますが、よろしいですか？" } %>
+      </div>
+    <% else %>
+      <div class="alert alert-info">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current shrink-0 w-6 h-6">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+        </svg>
+        <span>減損処理可能な在庫がありません。</span>
+      </div>
+    <% end %>
+  <% end %>
+</div>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    const selectAllBtn = document.getElementById('select-all');
+    const deselectAllBtn = document.getElementById('deselect-all');
+    const checkboxes = document.querySelectorAll('input[type="checkbox"][name="stock_ids[]"]');
+    const submitBtn = document.getElementById('impairment-submit');
+
+    if (selectAllBtn) {
+      selectAllBtn.addEventListener('click', function() {
+        checkboxes.forEach(checkbox => {
+          checkbox.checked = true;
+        });
+        updateSubmitButton();
+      });
+    }
+
+    if (deselectAllBtn) {
+      deselectAllBtn.addEventListener('click', function() {
+        checkboxes.forEach(checkbox => {
+          checkbox.checked = false;
+        });
+        updateSubmitButton();
+      });
+    }
+
+    function updateSubmitButton() {
+      const checkedCount = Array.from(checkboxes).filter(cb => cb.checked).length;
+      if (submitBtn) {
+        submitBtn.disabled = checkedCount === 0;
+      }
+    }
+
+    checkboxes.forEach(checkbox => {
+      checkbox.addEventListener('change', updateSubmitButton);
+    });
+
+    // 初期状態でボタンを無効化
+    updateSubmitButton();
+  });
+</script>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -8,10 +8,13 @@
     <ul class="menu menu-horizontal px-1">
       <% if logged_in? %>
         <li>
+          <%= link_to "在庫登録", new_stock_path, class: "btn btn-ghost" %>
+        </li>
+        <li>
           <%= link_to "在庫一覧", stocks_path, class: "btn btn-ghost" %>
         </li>
         <li>
-          <%= link_to "在庫登録", new_stock_path, class: "btn btn-ghost" %>
+          <%= link_to "減損処理", impairments_path, class: "btn btn-ghost" %>
         </li>
         <li>
           <%= link_to "ログアウト", logout_path, data: { turbo_method: :delete }, class: "btn btn-ghost" %>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,14 +1,38 @@
-<div class="space-y-4">
-  <h1 class="text-4xl font-bold">デザインシステム確認</h1>
-  
+<div class="space-y-6">
+  <h1 class="text-4xl font-bold text-center mb-8">ダッシュボード</h1>
+
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+    <!-- 在庫金額総額 -->
+    <div class="card bg-base-100 shadow-xl">
+      <div class="card-body">
+        <h2 class="card-title text-lg text-gray-600 mb-2">在庫金額総額</h2>
+        <p class="text-4xl font-bold text-primary">
+          <%= number_to_currency(@total_inventory_value, unit: "¥", format: "%u %n", precision: 0) %>
+        </p>
+        <p class="text-sm text-gray-500 mt-2">ステータスが「完了」以外の在庫の帳簿価額の合計</p>
+      </div>
+    </div>
+
+    <!-- 知識資産総額 -->
+    <div class="card bg-base-100 shadow-xl">
+      <div class="card-body">
+        <h2 class="card-title text-lg text-gray-600 mb-2">知識資産総額</h2>
+        <p class="text-4xl font-bold text-success">
+          <%= number_to_currency(@total_knowledge_asset_value, unit: "¥", format: "%u %n", precision: 0) %>
+        </p>
+        <p class="text-sm text-gray-500 mt-2">ステータスが「完了」の在庫の帳簿価額の合計</p>
+      </div>
+    </div>
+  </div>
+
+  <!-- 減損損失累計額 -->
   <div class="card bg-base-100 shadow-xl">
     <div class="card-body">
-      <h2 class="card-title">daisyUIカード</h2>
-      <p>daisyUIが正しく読み込まれています。</p>
-      <div class="card-actions justify-end">
-        <button class="btn btn-primary">Primary</button>
-        <button class="btn btn-secondary">Secondary</button>
-      </div>
+      <h2 class="card-title text-lg text-gray-600 mb-2">減損損失累計額</h2>
+      <p class="text-3xl font-bold text-error">
+        <%= number_to_currency(@total_impairment_loss, unit: "¥", format: "%u %n", precision: 0) %>
+      </p>
+      <p class="text-sm text-gray-500 mt-2">ステータスが「完了」以外の在庫の減損損失の合計</p>
     </div>
   </div>
 </div>

--- a/app/views/stocks/_form.html.erb
+++ b/app/views/stocks/_form.html.erb
@@ -34,6 +34,11 @@
       <span class="label-text">購入金額（円） <span class="text-error">*</span></span>
     <% end %>
     <%= f.number_field :purchase_price, class: "input input-bordered w-full", placeholder: "0", min: 0, step: 1, required: true %>
+    <% unless @stock.new_record? %>
+      <div class="label">
+        <span class="label-text-alt text-gray-500">帳簿価額: <%= number_to_currency(@stock.book_value || 0, unit: "¥", format: "%u %n", precision: 0) %></span>
+      </div>
+    <% end %>
   </div>
 
   <div class="form-control">

--- a/app/views/stocks/index.html.erb
+++ b/app/views/stocks/index.html.erb
@@ -14,25 +14,29 @@
                 <span class="font-semibold">カテゴリ:</span>
                 <span class="badge badge-outline"><%= stock.category.name %></span>
               </p>
-              <% if stock.purchase_price %>
-                <p>
-                  <span class="font-semibold">購入金額:</span>
-                  <span><%= number_to_currency(stock.purchase_price, unit: "¥", format: "%u %n", precision: 0) %></span>
-                </p>
-              <% end %>
-              <% if stock.purchase_date %>
-                <p>
-                  <span class="font-semibold">購入日:</span>
-                  <span><%= stock.purchase_date.strftime("%Y年%m月%d日") %></span>
-                </p>
-              <% end %>
+              <p>
+                <span class="font-semibold">購入金額:</span>
+                <span><%= number_to_currency(stock.purchase_price, unit: "¥", format: "%u %n", precision: 0) %></span>
+              </p>
+              <p>
+                <span class="font-semibold">帳簿価額:</span>
+                <span><%= number_to_currency(stock.book_value || 0, unit: "¥", format: "%u %n", precision: 0) %></span>
+              </p>
+              <p>
+                <span class="font-semibold">減損損失:</span>
+                <span class="text-error"><%= number_to_currency(stock.impairment_loss || 0, unit: "¥", format: "%u %n", precision: 0) %></span>
+              </p>
+              <p>
+                <span class="font-semibold">購入日:</span>
+                <span><%= stock.purchase_date.strftime("%Y年%m月%d日") %></span>
+              </p>
               <p>
                 <span class="font-semibold">ステータス:</span>
                 <span class="badge <%= status_badge_class(stock.status) %>"><%= I18n.t("activerecord.enums.stock.status.#{stock.status}") %></span>
               </p>
-              <% if stock.impression.present? %>
-                <p class="text-sm text-gray-600 overflow-hidden text-ellipsis line-clamp-2"><%= truncate(stock.impression, length: 100) %></p>
-              <% end %>
+              <p class="text-sm text-gray-600 overflow-hidden text-ellipsis line-clamp-1 break-words min-h-[1.5rem]">
+                <%= stock.impression.present? ? stock.impression : "&nbsp;".html_safe %>
+              </p>
             </div>
             <div class="card-actions justify-end mt-4">
               <%= link_to "詳細", stock_path(stock), class: "btn btn-sm btn-info" %>

--- a/app/views/stocks/index.html.erb
+++ b/app/views/stocks/index.html.erb
@@ -7,9 +7,9 @@
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
       <% @stocks.each do |stock| %>
         <div class="card bg-base-100 shadow-xl">
-          <div class="card-body">
-            <h2 class="card-title"><%= stock.title %></h2>
-            <div class="space-y-2">
+          <div class="card-body overflow-hidden">
+            <h2 class="card-title break-words overflow-hidden"><%= stock.title %></h2>
+            <div class="space-y-2 overflow-hidden">
               <p>
                 <span class="font-semibold">カテゴリ:</span>
                 <span class="badge badge-outline"><%= stock.category.name %></span>
@@ -33,9 +33,6 @@
               <p>
                 <span class="font-semibold">ステータス:</span>
                 <span class="badge <%= status_badge_class(stock.status) %>"><%= I18n.t("activerecord.enums.stock.status.#{stock.status}") %></span>
-              </p>
-              <p class="text-sm text-gray-600 overflow-hidden text-ellipsis line-clamp-1 break-words min-h-[1.5rem]">
-                <%= stock.impression.present? ? stock.impression : "&nbsp;".html_safe %>
               </p>
             </div>
             <div class="card-actions justify-end mt-4">

--- a/app/views/stocks/show.html.erb
+++ b/app/views/stocks/show.html.erb
@@ -34,6 +34,13 @@
           </div>
 
           <div>
+            <h3 class="font-semibold text-lg mb-2">帳簿価額</h3>
+            <p class="text-xl">
+              <%= number_to_currency(@stock.book_value || 0, unit: "¥", format: "%u %n", precision: 0) %>
+            </p>
+          </div>
+
+          <div>
             <h3 class="font-semibold text-lg mb-2">購入日</h3>
             <p class="text-xl">
               <% if @stock.purchase_date %>
@@ -43,12 +50,19 @@
               <% end %>
             </p>
           </div>
+
+          <div>
+            <h3 class="font-semibold text-lg mb-2">減損損失</h3>
+            <p class="text-xl text-error">
+              <%= number_to_currency(@stock.impairment_loss || 0, unit: "¥", format: "%u %n", precision: 0) %>
+            </p>
+          </div>
         </div>
 
         <% if @stock.impression.present? %>
           <div>
             <h3 class="font-semibold text-lg mb-2">感想・メモ</h3>
-            <p class="whitespace-pre-wrap"><%= @stock.impression %></p>
+            <p class="break-words whitespace-pre-wrap"><%= @stock.impression %></p>
           </div>
         <% end %>
 

--- a/app/views/stocks/show.html.erb
+++ b/app/views/stocks/show.html.erb
@@ -12,7 +12,7 @@
     <div class="card-body">
       <div class="space-y-6">
         <div>
-          <h2 class="text-2xl font-bold mb-2"><%= @stock.title %></h2>
+          <h2 class="text-2xl font-bold mb-2 break-words overflow-hidden"><%= @stock.title %></h2>
           <div class="flex gap-2 mt-2">
             <span class="badge badge-outline"><%= @stock.category.name %></span>
             <span class="badge <%= status_badge_class(@stock.status) %>"><%= I18n.t("activerecord.enums.stock.status.#{@stock.status}") %></span>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -17,6 +17,11 @@ ja:
       created: "メモを投稿しました。"
       create_failed: "メモの投稿に失敗しました。入力内容を確認してください。"
       destroyed: "メモを削除しました。"
+    impairments:
+      processed: "%{count}件の在庫に減損処理を実行しました。"
+      no_selection: "減損処理する在庫を選択してください。"
+      invalid_selection: "無効な在庫が選択されています。"
+      process_failed: "減損処理の実行に失敗しました。"
   activerecord:
     models:
       stock: "在庫"
@@ -25,6 +30,8 @@ ja:
       stock:
         title: "タイトル"
         purchase_price: "購入金額"
+        book_value: "帳簿価額"
+        impairment_loss: "減損損失"
         purchase_date: "購入日"
         status: "ステータス"
         impression: "感想"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ Rails.application.routes.draw do
     resources :memos, only: %i[create destroy]
   end
 
+  resources :impairments, only: %i[index create]
+
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check

--- a/db/migrate/20260108173236_add_book_value_and_impairment_loss_to_stocks.rb
+++ b/db/migrate/20260108173236_add_book_value_and_impairment_loss_to_stocks.rb
@@ -2,13 +2,14 @@
 
 class AddBookValueAndImpairmentLossToStocks < ActiveRecord::Migration[8.1]
   def up
-    # カラムを追加
-    add_column :stocks, :book_value, :integer
-    add_column :stocks, :impairment_loss, :integer
+    change_table :stocks, bulk: true do |t|
+      t.integer :book_value
+      t.integer :impairment_loss
+    end
 
     # 既存データのマイグレーション
     # book_valueにpurchase_priceの値をコピー
-    execute <<-SQL
+    execute <<-SQL.squish
       UPDATE stocks
       SET book_value = purchase_price
       WHERE book_value IS NULL
@@ -16,19 +17,23 @@ class AddBookValueAndImpairmentLossToStocks < ActiveRecord::Migration[8.1]
 
     # impairment_lossを計算（purchase_price - book_value）
     # 初期状態ではbook_value = purchase_priceなので、impairment_loss = 0
-    execute <<-SQL
+    execute <<-SQL.squish
       UPDATE stocks
       SET impairment_loss = COALESCE(purchase_price, 0) - COALESCE(book_value, 0)
       WHERE impairment_loss IS NULL
     SQL
 
     # デフォルト値を0に設定（新規レコード用）
+    # rubocop:disable Rails/BulkChangeTable
     change_column_default :stocks, :book_value, 0
     change_column_default :stocks, :impairment_loss, 0
+    # rubocop:enable Rails/BulkChangeTable
   end
 
   def down
-    remove_column :stocks, :book_value
-    remove_column :stocks, :impairment_loss
+    change_table :stocks, bulk: true do |t|
+      t.remove :book_value
+      t.remove :impairment_loss
+    end
   end
 end

--- a/db/migrate/20260108173236_add_book_value_and_impairment_loss_to_stocks.rb
+++ b/db/migrate/20260108173236_add_book_value_and_impairment_loss_to_stocks.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class AddBookValueAndImpairmentLossToStocks < ActiveRecord::Migration[8.1]
+  def up
+    # カラムを追加
+    add_column :stocks, :book_value, :integer
+    add_column :stocks, :impairment_loss, :integer
+
+    # 既存データのマイグレーション
+    # book_valueにpurchase_priceの値をコピー
+    execute <<-SQL
+      UPDATE stocks
+      SET book_value = purchase_price
+      WHERE book_value IS NULL
+    SQL
+
+    # impairment_lossを計算（purchase_price - book_value）
+    # 初期状態ではbook_value = purchase_priceなので、impairment_loss = 0
+    execute <<-SQL
+      UPDATE stocks
+      SET impairment_loss = COALESCE(purchase_price, 0) - COALESCE(book_value, 0)
+      WHERE impairment_loss IS NULL
+    SQL
+
+    # デフォルト値を0に設定（新規レコード用）
+    change_column_default :stocks, :book_value, 0
+    change_column_default :stocks, :impairment_loss, 0
+  end
+
+  def down
+    remove_column :stocks, :book_value
+    remove_column :stocks, :impairment_loss
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_08_154429) do
+ActiveRecord::Schema[8.1].define(version: 2026_01_08_173236) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -32,8 +32,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_08_154429) do
   end
 
   create_table "stocks", force: :cascade do |t|
+    t.integer "book_value", default: 0
     t.bigint "category_id", null: false
     t.datetime "created_at", null: false
+    t.integer "impairment_loss", default: 0
     t.text "impression"
     t.date "purchase_date"
     t.integer "purchase_price"


### PR DESCRIPTION
## 実装・確認内容

### 1. データベース変更 (Stockモデル)

#### マイグレーション (`db/migrate/20260108173236_add_book_value_and_impairment_loss_to_stocks.rb`)
- ✅ `stocks`テーブルに`book_value`（帳簿価額）カラムを追加（integer型）
- ✅ `stocks`テーブルに`impairment_loss`（減損損失）カラムを追加（integer型）
- ✅ 既存データのマイグレーション処理を実装
  - `book_value`に`purchase_price`の値をコピー
  - `impairment_loss`を計算（`purchase_price - book_value`）
  - 初期状態では`book_value = purchase_price`なので、`impairment_loss = 0`
- ✅ デフォルト値を0に設定
- ✅ ロールバック処理を実装

#### Stockモデル (`app/models/stock.rb`)
- ✅ `before_validation`コールバックを追加
  - 新規作成時: `book_value`に`purchase_price`を自動コピー
  - 編集時（購入金額変更時）: `book_value`を`purchase_price`に自動更新
  - `impairment_loss`を自動計算（`purchase_price - book_value`）
  - `impairment_loss`は0円以上に制限
- ✅ スコープを追加
  - `not_completed`: 完了以外の在庫
- ✅ 集計メソッド（クラスメソッド）を実装
  - `total_inventory_value`: 在庫金額総額（完了以外の`book_value`の合計）
  - `total_knowledge_asset_value`: 知識資産総額（完了の`book_value`の合計）
  - `total_impairment_loss`: 減損損失累計額（完了以外の`impairment_loss`の合計）

### 2. 減損処理機能の実装

#### ルーティング (`config/routes.rb`)
- ✅ `resources :impairments, only: [:index, :create]`を追加

#### コントローラー (`app/controllers/impairments_controller.rb`)
- ✅ `index`アクション: 完了以外の在庫一覧を表示
- ✅ `create`アクション: 減損処理を実行
  - 選択された在庫を取得（自分の在庫のみ、完了以外）
  - トランザクション内で処理を実行
  - ステータスを「減損損失(impaired: 40)」に変更
  - `book_value`を1円に設定
  - `impairment_loss`を再計算（`purchase_price - book_value`）
  - `purchase_price`は変更しない
  - ダッシュボード（`root_path`）へリダイレクト
- ✅ エラーハンドリングを実装
- ✅ 選択なし、無効な選択時のバリデーションを実装

#### ビュー (`app/views/impairments/index.html.erb`)
- ✅ 完了以外の在庫一覧を表示
- ✅ 各在庫にチェックボックスを配置
- ✅ 「全て選択」「全て解除」ボタンを追加
- ✅ 「減損処理実行」ボタンを追加（赤字、目立つデザイン）
- ✅ 確認ポップアップを実装（`turbo_confirm`）
- ✅ JavaScriptでチェックボックスの選択状態に応じてボタンを有効/無効化
- ✅ 在庫カードに購入金額、帳簿価額、減損損失を表示

### 3. ダッシュボード画面 (Topページ)

#### コントローラー (`app/controllers/static_pages_controller.rb`)
- ✅ `before_action :require_login`を追加（ログイン必須）
- ✅ `top`アクションで集計データを取得
  - `@total_inventory_value`: 在庫金額総額
  - `@total_knowledge_asset_value`: 知識資産総額
  - `@total_impairment_loss`: 減損損失累計額

#### ビュー (`app/views/static_pages/top.html.erb`)
- ✅ ダッシュボード画面を実装
- ✅ 左側：在庫金額総額を大きく表示（プライマリカラー）
- ✅ 右側：知識資産総額を大きく表示（成功カラー）
- ✅ 下部：減損損失累計額を表示（エラーカラー）
- ✅ 金額は`number_to_currency`を使用し、円マーク付き、3桁区切りで表示
- ✅ 各項目に説明文を追加

### 4. 既存画面の改修

#### ヘッダー (`app/views/shared/_header.html.erb`)
- ✅ 並び順を変更：「在庫登録」「在庫一覧」「減損処理」「ログアウト」

#### 在庫一覧画面 (`app/views/stocks/index.html.erb`)
- ✅ `purchase_price`の下に`book_value`（帳簿価額）を表示
- ✅ 減損損失を常時表示（0円の場合も表示）
- ✅ 購入金額、購入日を常時表示（必ず値が存在する前提）
- ✅ 感想メモを1行のみ表示（`line-clamp-1`を使用）
- ✅ 感想メモがない場合でも1行分のスペースを確保（`min-h-[1.5rem]`）
- ✅ 各在庫カードの表示項目を統一し、ボタン位置を揃える

#### 在庫詳細画面 (`app/views/stocks/show.html.erb`)
- ✅ 購入金額の下に`book_value`（帳簿価額）を表示
- ✅ 帳簿価額の下に減損損失を表示（同じ行位置に配置）
- ✅ 購入日と減損損失を同じ行に配置
- ✅ 感想メモの表示に`break-words`クラスを追加して改行対応

#### 在庫編集画面 (`app/views/stocks/_form.html.erb`)
- ✅ 編集時（新規作成時以外）に`book_value`（帳簿価額）を表示（readonly）

### 5. 日本語訳 (`config/locales/ja.yml`)

- ✅ `controllers.impairments.processed`: "%{count}件の在庫に減損処理を実行しました。"
- ✅ `controllers.impairments.no_selection`: "減損処理する在庫を選択してください。"
- ✅ `controllers.impairments.invalid_selection`: "無効な在庫が選択されています。"
- ✅ `controllers.impairments.process_failed`: "減損処理の実行に失敗しました。"
- ✅ `activerecord.attributes.stock.book_value`: "帳簿価額"
- ✅ `activerecord.attributes.stock.impairment_loss`: "減損損失"

### 6. バグ修正と改善

- ✅ 在庫登録時に`book_value`が正しく設定されない問題を修正（`before_validation`に変更）
- ✅ 在庫編集時に購入金額を変更した場合、`book_value`が自動更新されるように改善
- ✅ マイグレーション実行後のエラーを回避するため、`has_attribute?`チェックを追加

## 実装の詳細

### 減損処理のロジック
1. ユーザーが減損処理画面で在庫を選択
2. 「減損処理実行」ボタンをクリック
3. 確認ポップアップで確認
4. 選択された在庫に対して以下を実行：
   - ステータスを「減損損失(impaired: 40)」に変更
   - `book_value`を1円に設定
   - `impairment_loss`を再計算（`purchase_price - book_value`）
   - `purchase_price`は変更しない
5. ダッシュボードへリダイレクト

### 集計ロジック
- **在庫金額総額**: ステータスが「完了」以外の在庫の`book_value`の合計
- **知識資産総額**: ステータスが「完了」の在庫の`book_value`の合計
- **減損損失累計額**: ステータスが「完了」以外の在庫の`impairment_loss`の合計

### 自動更新ロジック
- **新規作成時**: `book_value`に`purchase_price`をコピー
- **編集時（購入金額変更時）**: `book_value`を`purchase_price`に更新
- **減損損失**: 常に`purchase_price - book_value`で計算

### セキュリティ
- ログイン必須（`before_action :require_login`）
- 自分の在庫のみ処理可能（`current_user.stocks`を使用）
- 完了以外の在庫のみ処理対象（`not_completed`スコープ）
- トランザクションでデータ整合性を保証

## 変更ファイル

- `db/migrate/20260108173236_add_book_value_and_impairment_loss_to_stocks.rb` (新規作成)
- `app/models/stock.rb` (修正)
- `config/routes.rb` (修正)
- `app/controllers/impairments_controller.rb` (新規作成)
- `app/controllers/static_pages_controller.rb` (修正)
- `app/controllers/stocks_controller.rb` (修正: showアクションにメモのincludes追加)
- `app/views/impairments/index.html.erb` (新規作成)
- `app/views/static_pages/top.html.erb` (修正)
- `app/views/shared/_header.html.erb` (修正)
- `app/views/stocks/index.html.erb` (修正)
- `app/views/stocks/show.html.erb` (修正)
- `app/views/stocks/_form.html.erb` (修正)
- `config/locales/ja.yml` (修正)

## テスト項目

### データベースとモデル
- [x] マイグレーション実行後、`book_value`と`impairment_loss`カラムが追加されること
- [x] 既存データの`book_value`が`purchase_price`の値で初期化されること
- [x] 既存データの`impairment_loss`が0で初期化されること
- [x] 新規在庫作成時に`book_value`が`purchase_price`の値で自動設定されること
- [x] 新規在庫作成時に`impairment_loss`が0で自動設定されること
- [x] 在庫編集時に購入金額を変更すると、`book_value`が自動更新されること
- [x] 在庫編集時に購入金額を変更すると、`impairment_loss`が再計算されること

### ダッシュボード
- [x] ダッシュボード画面に在庫金額総額が正しく表示されること
- [x] ダッシュボード画面に知識資産総額が正しく表示されること
- [x] ダッシュボード画面に減損損失累計額が正しく表示されること
- [x] 金額が円マーク付き、3桁区切りで表示されること

### 減損処理機能
- [x] 減損処理画面に完了以外の在庫のみが表示されること
- [x] 減損処理画面で在庫を選択できること
- [x] 「全て選択」「全て解除」ボタンが正常に動作すること
- [x] チェックボックスが選択されていない場合、「減損処理実行」ボタンが無効化されること
- [x] 「減損処理実行」ボタンをクリックすると確認ポップアップが表示されること
- [x] 確認ポップアップで「キャンセル」を選択した場合、処理が実行されないこと
- [x] 確認ポップアップで「OK」を選択した場合、減損処理が実行されること
- [x] 減損処理実行後、選択された在庫のステータスが「減損損失」に変更されること
- [x] 減損処理実行後、選択された在庫の`book_value`が1円になること
- [x] 減損処理実行後、選択された在庫の`impairment_loss`が正しく計算されること
- [x] 減損処理実行後、選択された在庫の`purchase_price`が変更されないこと
- [x] 減損処理実行後、ダッシュボードへリダイレクトされること
- [x] 減損処理実行後、フラッシュメッセージが表示されること

### 画面表示
- [x] 在庫一覧画面に`book_value`が表示されること
- [x] 在庫一覧画面に減損損失が常に表示されること（0円の場合も）
- [x] 在庫一覧画面の各在庫カードでボタン位置が揃うこと
- [x] 在庫詳細画面に`book_value`が表示されること
- [x] 在庫詳細画面に減損損失が表示されること
- [x] 在庫詳細画面で購入日と減損損失が同じ行に配置されること
- [x] 在庫編集画面に`book_value`が表示されること（readonly）

### セキュリティ
- [x] ログインしていないユーザーが減損処理を実行しようとした場合、ログイン画面にリダイレクトされること
- [x] 他人の在庫に対して減損処理を実行しようとした場合、エラーになること
- [x] 完了済みの在庫に対して減損処理を実行しようとした場合、対象にならないこと

### UI/UX
- [x] ヘッダーの並び順が「在庫登録」「在庫一覧」「減損処理」「ログアウト」になっていること
- [x] 減損処理画面の「減損処理実行」ボタンが目立つデザイン（赤字）であること
- [x] ダッシュボードの各項目が分かりやすく表示されること